### PR TITLE
avoid arguments.callee, implement self-calling constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ jParser Constructor:
     * ``data`` is a [jDataView](https://github.com/vjeux/jDataView). You can give pretty much anything (String, [ArrayBuffer](https://developer.mozilla.org/en/JavaScript_typed_arrays), [Node Buffer](http://nodejs.org/docs/v0.6.2/api/buffers.html)), it will be casted to jDataView automatically.
     * ``structure`` is an object with all the defined structures.
 
+It implements [John Resig's self-calling constructor](http://ejohn.org/blog/simple-class-instantiation/) interface, so you may use simple `jParser(data, structure)` instead of `new jParser(data, structure)` if you like it.
+
 Examples
 ========
 
@@ -45,7 +47,7 @@ Examples
 You have the ability to define C-like structures. It's a Javascript object where keys are labels and values are types.
 
 ```javascript
-var parser = new jParser(file, {
+var parser = jParser(file, {
   header: {
     fileId: 'int32',
     recordIndex: 'int32',
@@ -163,7 +165,7 @@ var fs = require('fs');
 var jParser = require('jParser');
 
 fs.readFile('file.bin', function (err, data) {
-  var parser = new jParser(data, {
+  var parser = jParser(data, {
     magic: ['array', 'uint8', 4]
   });
   console.log(parser.parse('magic'));
@@ -179,7 +181,7 @@ fs.readFile('file.bin', function (err, data) {
 
 <script>
 $.get('file.bin', function (data) {
-  var parser = new jParser(data, {
+  var parser = jParser(data, {
     magic: ['array', 'uint8', 4]
   });
   console.log(parser.parse('magic'));

--- a/src/jparser.js
+++ b/src/jparser.js
@@ -19,7 +19,7 @@ var extend = function (obj) {
 };
 
 function jParser(view, structure) {
-	if (!(this instanceof arguments.callee)) {
+	if (!(this instanceof jParser)) {
 		throw new Error("Constructor may not be called as a function");
 	}
 	if (!(view instanceof jDataView)) {

--- a/src/jparser.js
+++ b/src/jparser.js
@@ -19,8 +19,10 @@ var extend = function (obj) {
 };
 
 function jParser(view, structure) {
+	// John Resig's self-calling constructor,
+	// see http://ejohn.org/blog/simple-class-instantiation/ for details.
 	if (!(this instanceof jParser)) {
-		throw new Error("Constructor may not be called as a function");
+		return new jParser(view, structure);
 	}
 	if (!(view instanceof jDataView)) {
 		view = new jDataView(view);

--- a/src/jparser.js
+++ b/src/jparser.js
@@ -42,7 +42,7 @@ jParser.prototype.structure = {
 	uint8: function () { return this.view.getUint8(); },
 	uint16: function () { return this.view.getUint16(undefined, true); },
 	uint32: function () { return this.view.getUint32(undefined, true); },
-	int8: function () { return this.view.getInt8(undefined, true); },
+	int8: function () { return this.view.getInt8(); },
 	int16: function () { return this.view.getInt16(undefined, true); },
 	int32: function () { return this.view.getInt32(undefined, true); },
 	float32: function () { return this.view.getFloat32(undefined, true); },

--- a/src/jparser.js
+++ b/src/jparser.js
@@ -4,7 +4,6 @@ if (typeof jDataView === 'undefined' && typeof require !== 'undefined') {
 	jDataView = require('jDataView');
 }
 
-
 // Extend code from underscorejs
 var extend = function (obj) {
 	for (var i = 1; i < arguments.length; ++i) {
@@ -41,13 +40,13 @@ function toInt(val) {
 
 jParser.prototype.structure = {
 	uint8: function () { return this.view.getUint8(); },
-	uint16: function () { return this.view.getUint16(); },
-	uint32: function () { return this.view.getUint32(); },
-	int8: function () { return this.view.getInt8(); },
-	int16: function () { return this.view.getInt16(); },
-	int32: function () { return this.view.getInt32(); },
-	float32: function () { return this.view.getFloat32(); },
-	float64: function () { return this.view.getFloat64(); },
+	uint16: function () { return this.view.getUint16(undefined, true); },
+	uint32: function () { return this.view.getUint32(undefined, true); },
+	int8: function () { return this.view.getInt8(undefined, true); },
+	int16: function () { return this.view.getInt16(undefined, true); },
+	int32: function () { return this.view.getInt32(undefined, true); },
+	float32: function () { return this.view.getFloat32(undefined, true); },
+	float64: function () { return this.view.getFloat64(undefined, true); },
 	char: function () { return this.view.getChar(); },
 	string: function (length) {
 		return this.view.getString(toInt.call(this, length));


### PR DESCRIPTION
As [MDN docs](https://developer.mozilla.org/en/JavaScript/Reference/Functions_and_function_scope/arguments/callee) say, `arguments.callee` is expensive, and forbidden in ECMAScript 5 strict mode, and should be avoided in favour of the function's name unless it's anonymous.

Ease of use would also benefit from using [John Resig's self-calling constructor](http://ejohn.org/blog/simple-class-instantiation/) interface, so that `new jParser(view, structure)` works exactly like `jParser(view, structure)` and `new` may be omitted if the module's user likes it that way.
